### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,6 @@
 name: Validate Pull Request
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/veillette/hands-on/security/code-scanning/3](https://github.com/veillette/hands-on/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the workflow, either at the root level—above `jobs`—to affect all jobs, or at the job level for specific fine-grained control. The minimal permission for safe validation workflows is `contents: read`, which limits GITHUB_TOKEN to read-only access to repository contents. Since there is no use of write privileges in any job, `contents: read` is sufficient. Edit `.github/workflows/validate.yml` by inserting:

```yaml
permissions:
  contents: read
```

Add this block at line 2 (after the workflow `name` and before `on:` block), so that all jobs will inherit these minimal permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
