### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   check-links:
     name: Validate Links
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/veillette/hands-on/security/code-scanning/1](https://github.com/veillette/hands-on/security/code-scanning/1)

To address the issue, explicitly add a `permissions` block with least privileges necessary for the job. In this workflow, all operations only require read access to repository contents (for checkout, build, and link check operations), and do not need write access to issues, pull requests, or any other resource. Therefore, add `permissions: contents: read` to the job definition (`check-links`) in `.github/workflows/link-check.yml` immediately under line 14. No other code or resources need updating.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
