### PR TITLE
Fix build export errors in Chapter2 and Chapter3

### DIFF
--- a/content/Chapter2.md
+++ b/content/Chapter2.md
@@ -91,15 +91,15 @@ This uncertainty value (±0.2 cm) represents the **absolute uncertainty** of our
 :::{list-table} Impact of Uncertainty in Different Contexts
 :header-rows: 1
 
-- - Context
-- Impact of ±0.2 cm
-- - Measuring microchip components
-- Substantial
-- - Measuring furniture
-- Acceptable
-- - Measuring astronomical distances
+* - Context
+  - Impact of ±0.2 cm
+* - Measuring microchip components
+  - Substantial
+* - Measuring furniture
+  - Acceptable
+* - Measuring astronomical distances
   - Negligible
-    :::
+:::
 
 To better evaluate a measurement's quality, we use **relative uncertainty**, defined as:
 
@@ -241,6 +241,8 @@ This accounts for the worst case where uncertainties combine to maximize the tot
 
 :::{iframe} https://preview.p5js.org/veillette/embed/0tDJ0eSDw
 :width: 800
+
+Interactive demonstration of uncertainty propagation in addition and subtraction.
 :::
 
 ### Products and Quotients

--- a/content/Chapter3.md
+++ b/content/Chapter3.md
@@ -132,8 +132,11 @@ $$\frac{\sigma_z}{z} = |n| \frac{\sigma_x}{x}$$
 These rules assume the measurements are independent and the uncertainties are random (not systematic). For systematic errors, the propagation rules are different.
 :::
 
-:::{example}
+:::{admonition} Example
+:class: example
+
 If we measure a rectangle's length as $(25.4 \pm 0.2)$ cm and width as $(18.6 \pm 0.2)$ cm, what is the uncertainty in the area?
+
 **Solution**:
 
 1. Calculate the area: $A = L \times W = 25.4 \text{cm} \times 18.6 \text{cm} = 472.44 \text{cm}^2$
@@ -148,7 +151,7 @@ If we measure a rectangle's length as $(25.4 \pm 0.2)$ cm and width as $(18.6 \p
    $$\sigma_A = \sqrt{0.0001775} \times 472.44 \text{cm}^2 \approx 6.3 \ \text{cm}^2$$
    $$
 4. Final result: $A = (472 \pm 6) \ \text{cm}^2$
-   :::
+:::
 
 ### Statistical vs. Estimated Uncertainties
 


### PR DESCRIPTION
- Fix iframe directive in Chapter2 by adding caption text to prevent typst figure syntax error
- Fix list-table directive in Chapter2 by using correct MyST markdown format with asterisks
- Fix unknown 'example' directive in Chapter3 by converting to admonition with example class

These changes resolve the following build errors:
- "error: unexpected comma" in typst figure generation
- "list-table directive must have one list as body"
- "unknown directive: example"